### PR TITLE
Add/fix 2024.3 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
+## [2025.1.1]
+### Fixed
+
+- Support 2024.3.x - 2025.2.x
+
 ## [2025.1]
+
 ### Fixed
 
 - Major rework to fix issues with slow operation blocking GUI EDT thread. This aligns to current IntelliJ plugin
   requirements
 
 ### Added
+
 - Support for user-defined git references as scopes
 - Ensure opened files will retain cursor position
 - For multi-repo layouts, display main repo first in list
@@ -15,27 +22,35 @@
 - Always retain scroll position in VCS tree window
 
 ## [2023.1.5]
+
 ### Fixed
 
 - "Only Changes Since Common Ancestor": Improved Git comparison accuracy by using GitHistoryUtils.history() with a
   two-dot syntax (git diff A..B)
 
 ## [2023.1.4]
+
 ### Added
 
 - "Only Changes Since Common Ancestor"-Checkbox: Allows to compare changes that were made only on this branch
 - VcsContextMenu-Action: Compare any commit with Git Scope
 
 ## [2023.1.3]
+
 ### Fixed
+
 - @NotNull parameter 'value' of state/MyModelConverter.fromString must not be null
 
 ## [2023.1.2]
+
 ### Fixed
+
 - Fix compatibility issues
 
 ## [2023.1.1]
+
 ### Fixed
+
 - Complete overhaul of the plugin
 - Cleaner UI
 - Tab-based tool window

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 pluginGroup=org.woelkit.plugins
 pluginName=Git Scope
 pluginRepositoryUrl=https://github.com/comod/git-scope
-pluginVersion=2025.1
-pluginSinceBuild=241.1
+pluginVersion=2025.1.1
+pluginSinceBuild=243.*
 pluginUntilBuild=252.*
 
 platformType=IC

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,9 +1,5 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
-<idea-plugin
-        require-restart="true">
-    <!-- Public plugin name should be written in Title Case.
-         Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
-    <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
+<idea-plugin require-restart="true">
     <id>Git Scope</id>
     <name>Git Scope</name>
     <vendor>WOELKIT</vendor>


### PR DESCRIPTION
Here is the fix for not working "sinceBuild/pluginSinceBuild" configuration. I could only support 2024.3 since 2024.2 were missing some of the APIs that I had been using. So had draw the line there. I hope that does not exclude to many of the plugin users?

Will go ahead and merge this now to master, so that I can create a new 2025.1.2 pull request with removal of the paid plugin configuration. Hope this is ok :)