### PR TITLE
Fix/issue with 2026.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginSinceBuild=243
 
 platformType=IU
 #platformVersion=LATEST-EAP-SNAPSHOT
-platformVersion=2025.3.1
+platformVersion=2026.1
 
 platformBundledPlugins=Git4Idea
 gradleVersion=9.2.1

--- a/src/main/java/implementation/lineStatusTracker/CommitDiffWorkaround.java
+++ b/src/main/java/implementation/lineStatusTracker/CommitDiffWorkaround.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import system.Defs;
 
-import java.awt.*;
+import java.awt.Component;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -143,17 +143,9 @@ public class CommitDiffWorkaround implements Disposable {
         synchronized (this) {
             // Register the editor
             commitDiffEditors.computeIfAbsent(doc, k -> new HashSet<>()).add(editor);
-
-            // Pre-cache HEAD content if tracked
-            if (baseRevisionSwitcher.isTracked(doc)) {
-                if (baseRevisionSwitcher.getCachedHeadContent(doc) == null) {
-                    String headContent = fetchHeadRevisionContent(file);
-                    if (headContent != null) {
-                        baseRevisionSwitcher.cacheHeadContent(doc, headContent);
-                    }
-                }
-            }
         }
+
+        prefetchHeadContent(doc, file);
 
         // Check if a commit diff editor is currently selected - if so, activate HEAD base
         scheduleActivationIfCommitDiffSelected();
@@ -288,6 +280,7 @@ public class CommitDiffWorkaround implements Disposable {
      * custom base restored.
      */
     private void activateHeadBaseForAllCommitDiffs() {
+        List<Document> documentsToActivate = new ArrayList<>();
         synchronized (this) {
             for (Map.Entry<Document, Set<Editor>> entry : commitDiffEditors.entrySet()) {
                 Document doc = entry.getKey();
@@ -296,40 +289,12 @@ public class CommitDiffWorkaround implements Disposable {
                 if (diffEditors.isEmpty()) {
                     continue;
                 }
-
-                VirtualFile file = FileDocumentManager.getInstance().getFile(doc);
-                if (file == null) {
-                    continue;
-                }
-
-                if (!baseRevisionSwitcher.isTracked(doc)) {
-                    continue;
-                }
-
-                if (baseRevisionSwitcher.isShowingHeadBase(doc)) {
-                    continue;
-                }
-
-                // Get HEAD content (fetch if not cached)
-                String headContent = baseRevisionSwitcher.getCachedHeadContent(doc);
-                if (headContent == null) {
-                    headContent = fetchHeadRevisionContent(file);
-                    if (headContent != null) {
-                        baseRevisionSwitcher.cacheHeadContent(doc, headContent);
-                    }
-                }
-
-                if (headContent != null) {
-                    baseRevisionSwitcher.markShowingHeadBase(doc, true);
-                    activeCommitDiffs.add(doc);
-
-                    String finalHeadContent = headContent;
-                    ApplicationManager.getApplication().invokeLater(() -> {
-                        if (disposing.get()) return;
-                        baseRevisionSwitcher.switchToHeadBase(doc, finalHeadContent);
-                    }, ModalityState.defaultModalityState(), __ -> disposing.get());
-                }
+                documentsToActivate.add(doc);
             }
+        }
+
+        for (Document doc : documentsToActivate) {
+            activateHeadBaseForDocument(doc);
         }
     }
 
@@ -366,6 +331,84 @@ public class CommitDiffWorkaround implements Disposable {
                 baseRevisionSwitcher.switchToCustomBase(doc, customContent);
             }, ModalityState.defaultModalityState(), __ -> disposing.get());
         }
+    }
+
+    private void prefetchHeadContent(@NotNull Document document, @NotNull VirtualFile file) {
+        if (!baseRevisionSwitcher.isTracked(document) || baseRevisionSwitcher.getCachedHeadContent(document) != null) {
+            return;
+        }
+
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            String headContent = fetchHeadRevisionContent(file);
+            if (headContent == null) {
+                return;
+            }
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (disposing.get() || !baseRevisionSwitcher.isTracked(document)) return;
+                if (baseRevisionSwitcher.getCachedHeadContent(document) == null) {
+                    baseRevisionSwitcher.cacheHeadContent(document, headContent);
+                }
+            }, ModalityState.defaultModalityState(), __ -> disposing.get());
+        });
+    }
+
+    private void activateHeadBaseForDocument(@NotNull Document document) {
+        if (disposing.get() || !baseRevisionSwitcher.isTracked(document) || baseRevisionSwitcher.isShowingHeadBase(document)) {
+            return;
+        }
+        if (!hasCommitDiffEditorsFor(document)) {
+            return;
+        }
+
+        VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+        if (file == null) {
+            return;
+        }
+
+        String cachedHeadContent = baseRevisionSwitcher.getCachedHeadContent(document);
+        if (cachedHeadContent != null) {
+            applyHeadBase(document, cachedHeadContent);
+            return;
+        }
+
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            String headContent = fetchHeadRevisionContent(file);
+            if (headContent == null) {
+                return;
+            }
+
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (disposing.get()) return;
+                if (!baseRevisionSwitcher.isTracked(document) || baseRevisionSwitcher.isShowingHeadBase(document)) return;
+                if (!hasCommitDiffEditorsFor(document)) return;
+
+                if (baseRevisionSwitcher.getCachedHeadContent(document) == null) {
+                    baseRevisionSwitcher.cacheHeadContent(document, headContent);
+                }
+                applyHeadBase(document, headContent);
+            }, ModalityState.defaultModalityState(), __ -> disposing.get());
+        });
+    }
+
+    private void applyHeadBase(@NotNull Document document, @NotNull String headContent) {
+        if (disposing.get() || !baseRevisionSwitcher.isTracked(document) || baseRevisionSwitcher.isShowingHeadBase(document)) {
+            return;
+        }
+        if (!hasCommitDiffEditorsFor(document)) {
+            return;
+        }
+
+        baseRevisionSwitcher.markShowingHeadBase(document, true);
+        synchronized (this) {
+            activeCommitDiffs.add(document);
+        }
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (disposing.get()) return;
+            if (!baseRevisionSwitcher.isShowingHeadBase(document)) return;
+            baseRevisionSwitcher.switchToHeadBase(document, headContent);
+        }, ModalityState.defaultModalityState(), __ -> disposing.get());
     }
 
     private String fetchHeadRevisionContent(@NotNull VirtualFile file) {

--- a/src/main/java/implementation/lineStatusTracker/CommitDiffWorkaround.java
+++ b/src/main/java/implementation/lineStatusTracker/CommitDiffWorkaround.java
@@ -3,6 +3,7 @@ package implementation.lineStatusTracker;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.Alarm;
 import com.intellij.openapi.editor.Document;
@@ -52,6 +53,16 @@ public class CommitDiffWorkaround implements Disposable {
 
     // Callback interface for base revision switching
     private final BaseRevisionSwitcher baseRevisionSwitcher;
+
+    private static final class HeadContentSource {
+        private final ContentRevision beforeRevision;
+        private final String fallbackContent;
+
+        private HeadContentSource(@Nullable ContentRevision beforeRevision, @Nullable String fallbackContent) {
+            this.beforeRevision = beforeRevision;
+            this.fallbackContent = fallbackContent;
+        }
+    }
 
     /**
      * Interface for switching base revisions.
@@ -417,31 +428,29 @@ public class CommitDiffWorkaround implements Disposable {
                 return null;
             }
 
-            ChangeListManager changeListManager = ChangeListManager.getInstance(project);
-            Collection<Change> allChanges = changeListManager.getAllChanges();
+            HeadContentSource source = ReadAction.compute(() -> {
+                ChangeListManager changeListManager = ChangeListManager.getInstance(project);
+                Collection<Change> allChanges = changeListManager.getAllChanges();
 
-            // Find the change for this file
-            for (Change change : allChanges) {
-                VirtualFile changeFile = change.getVirtualFile();
-                if (changeFile != null && changeFile.equals(file)) {
-                    // The "before" revision is HEAD
-                    ContentRevision beforeRevision = change.getBeforeRevision();
-                    if (beforeRevision != null) {
-                        String content = beforeRevision.getContent();
-                        if (content != null) {
-                            return StringUtil.convertLineSeparators(content);
-                        }
+                for (Change change : allChanges) {
+                    VirtualFile changeFile = change.getVirtualFile();
+                    if (changeFile != null && changeFile.equals(file)) {
+                        return new HeadContentSource(change.getBeforeRevision(), null);
                     }
+                }
+
+                Document doc = FileDocumentManager.getInstance().getDocument(file);
+                return new HeadContentSource(null, doc != null ? doc.getText() : null);
+            });
+
+            if (source.beforeRevision != null) {
+                String content = source.beforeRevision.getContent();
+                if (content != null) {
+                    return StringUtil.convertLineSeparators(content);
                 }
             }
 
-            // File is not modified - current content IS HEAD
-            Document doc = FileDocumentManager.getInstance().getDocument(file);
-            if (doc != null) {
-                return doc.getText();
-            }
-
-            return null;
+            return source.fallbackContent != null ? StringUtil.convertLineSeparators(source.fallbackContent) : null;
         } catch (Exception e) {
             LOG.warn("Error fetching HEAD revision content for " + file.getName(), e);
             return null;

--- a/src/main/java/implementation/lineStatusTracker/MyLineStatusTrackerImpl.java
+++ b/src/main/java/implementation/lineStatusTracker/MyLineStatusTrackerImpl.java
@@ -67,6 +67,18 @@ public class MyLineStatusTrackerImpl implements Disposable {
         }
     }
 
+    private static final class TrackerUpdateRequest {
+        private final Document document;
+        private final String filePath;
+        private final Change change;
+
+        private TrackerUpdateRequest(@NotNull Document document, @NotNull String filePath, @Nullable Change change) {
+            this.document = document;
+            this.filePath = filePath;
+            this.change = change;
+        }
+    }
+
     @Override
     public void dispose() {
         disposalToken.disposed = true;
@@ -221,46 +233,75 @@ public class MyLineStatusTrackerImpl implements Disposable {
         ApplicationManager.getApplication().invokeLater(() -> {
             if (token.disposed) return;
 
-            Editor[] editors = EditorFactory.getInstance().getAllEditors();
-            for (Editor editor : editors) {
-                if (isDiffView(editor)) continue;
-                // Platform handles gutter repainting automatically - no need to force it
-                updateLineStatusByChangesForEditor(editor, scopeChangesMap);
-            }
+            Collection<TrackerUpdateRequest> requests = collectTrackerUpdateRequests(scopeChangesMap);
+            if (requests.isEmpty()) return;
+
+            ApplicationManager.getApplication().executeOnPooledThread(() -> {
+                Map<Document, String> resolvedContent = resolveRevisionContent(requests);
+                ApplicationManager.getApplication().invokeLater(() -> {
+                    if (token.disposed) return;
+                    applyTrackerUpdates(requests, resolvedContent);
+                }, ModalityState.defaultModalityState(), __ -> token.disposed);
+            });
         }, ModalityState.defaultModalityState(), __ -> token.disposed);
     }
 
-    private void updateLineStatusByChangesForEditor(Editor editor, Map<String, Change> scopeChangesMap) {
-        if (editor == null || disposing.get()) return;
+    private @NotNull Collection<TrackerUpdateRequest> collectTrackerUpdateRequests(@NotNull Map<String, Change> scopeChangesMap) {
+        Map<Document, TrackerUpdateRequest> requests = new LinkedHashMap<>();
+        Editor[] editors = EditorFactory.getInstance().getAllEditors();
+        for (Editor editor : editors) {
+            if (editor.isDisposed() || isDiffView(editor)) continue;
 
-        Document doc = editor.getDocument();
-        VirtualFile file = FileDocumentManager.getInstance().getFile(doc);
-        if (file == null) return;
+            Document document = editor.getDocument();
+            if (requests.containsKey(document)) continue;
 
-        String filePath = file.getPath();
+            VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+            if (file == null) continue;
 
-        // Look up the change for this editor's file using the map
-        Change changeForFile = scopeChangesMap.get(filePath);
-
-        String content;
-        if (changeForFile != null && changeForFile.getBeforeRevision() != null) {
-            // Extract content for this specific file only
-            try {
-                content = changeForFile.getBeforeRevision().getContent();
-            } catch (VcsException e) {
-                LOG.warn("Error getting content for revision: " + filePath, e);
-                content = null;
-            }
-
-            if (content == null) {
-                content = doc.getCharsSequence().toString();
-            }
-        } else {
-            // No revision content available, use current document content
-            content = doc.getCharsSequence().toString();
+            String filePath = file.getPath();
+            requests.put(document, new TrackerUpdateRequest(document, filePath, scopeChangesMap.get(filePath)));
         }
+        return requests.values();
+    }
 
-        updateTrackerBaseContent(doc, content);
+    private @NotNull Map<Document, String> resolveRevisionContent(@NotNull Collection<TrackerUpdateRequest> requests) {
+        Map<Document, String> resolvedContent = new HashMap<>();
+        for (TrackerUpdateRequest request : requests) {
+            Change change = request.change;
+            if (change == null || change.getBeforeRevision() == null) continue;
+
+            try {
+                String content = change.getBeforeRevision().getContent();
+                if (content != null) {
+                    resolvedContent.put(request.document, content);
+                }
+            } catch (VcsException e) {
+                LOG.warn("Error getting content for revision: " + request.filePath, e);
+            }
+        }
+        return resolvedContent;
+    }
+
+    private void applyTrackerUpdates(@NotNull Collection<TrackerUpdateRequest> requests,
+                                     @NotNull Map<Document, String> resolvedContent) {
+        for (TrackerUpdateRequest request : requests) {
+            if (!hasOpenMainEditor(request.document)) continue;
+
+            String content = resolvedContent.get(request.document);
+            if (content == null) {
+                content = request.document.getCharsSequence().toString();
+            }
+            updateTrackerBaseContent(request.document, content);
+        }
+    }
+
+    private boolean hasOpenMainEditor(@NotNull Document document) {
+        for (Editor editor : EditorFactory.getInstance().getAllEditors()) {
+            if (!editor.isDisposed() && !isDiffView(editor) && editor.getDocument() == document) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/listener/MyTabContentListener.java
+++ b/src/main/java/listener/MyTabContentListener.java
@@ -45,34 +45,28 @@ public class MyTabContentListener implements ContentManagerListener {
     }
 
     public void selectionChanged(@NotNull ContentManagerEvent event) {
-        ContentManagerEvent.ContentOperation operation = event.getOperation();
-        ContentManagerEvent.ContentOperation add = ContentManagerEvent.ContentOperation.add;
-
         @NlsContexts.TabTitle String tabName = event.getContent().getTabName();
-        if (operation.equals(add)) {
-            ViewService service = getViewService(); // Get service only when needed
-            service.setTabIndex(event.getIndex());
-            
-            if (Objects.equals(tabName, PLUS_TAB_LABEL)) {
-                SwingUtilities.invokeLater(service::plusTabClicked);
-                return;
-            }
+        ViewService service = getViewService();
+        service.setTabIndex(event.getIndex());
 
-            service.setTabIndex(event.getIndex());
-            service.setActiveModel();
-            
-            // Notify VcsTree about the tab switch
-            SwingUtilities.invokeLater(() -> {
-                try {
-                    VcsTree vcsTree = getToolWindowService().getVcsTree();
-                    if (vcsTree != null) {
-                        vcsTree.onTabSwitched();
-                    }
-                } catch (Exception e) {
-                    LOG.error("MyTabContentListener: Error notifying VcsTree about tab switch: " + e.getMessage());
-                }
-            });
+        if (Objects.equals(tabName, PLUS_TAB_LABEL)) {
+            SwingUtilities.invokeLater(service::plusTabClicked);
+            return;
         }
+
+        service.setActiveModel();
+
+        // Notify VcsTree about the tab switch
+        SwingUtilities.invokeLater(() -> {
+            try {
+                VcsTree vcsTree = getToolWindowService().getVcsTree();
+                if (vcsTree != null) {
+                    vcsTree.onTabSwitched();
+                }
+            } catch (Exception e) {
+                LOG.error("MyTabContentListener: Error notifying VcsTree about tab switch: " + e.getMessage());
+            }
+        });
     }
 
     public void contentRemoved(@NotNull ContentManagerEvent event) {

--- a/src/main/java/service/ViewService.java
+++ b/src/main/java/service/ViewService.java
@@ -48,7 +48,7 @@ public class ViewService implements Disposable {
     public static final String PLUS_TAB_LABEL = "+";
     public static final int DEBOUNCE_MS = 50;
     public List<MyModel> collection = new ArrayList<>();
-    public Integer currentTabIndex = 0;
+    private volatile int currentTabIndex = 0;
     private final Project project;
     private volatile boolean isDisposed = false;
 
@@ -715,43 +715,7 @@ public class ViewService implements Disposable {
     }
 
     public MyModel getCurrent() {
-        // Check if disposed or not initialized
-        if (isDisposed || toolWindowService == null) {
-            return myHeadModel; // Safe fallback
-        }
-
-        // Get tool window safely
-        ToolWindow toolWindow = toolWindowService.getToolWindow();
-        if (toolWindow == null) {
-            return myHeadModel; // Tool window not available
-        }
-
-        // Get the currently selected tab's model directly from ContentManager
-        ContentManager contentManager = toolWindow.getContentManager();
-        Content selectedContent = contentManager.getSelectedContent();
-
-        if (selectedContent == null) {
-            return myHeadModel;
-        }
-
-        // Check if it's the HEAD tab
-        if (selectedContent.getTabName().equals(GitService.BRANCH_HEAD)) {
-            return myHeadModel;
-        }
-
-        // Check if it's the + tab
-        if (selectedContent.getTabName().equals(PLUS_TAB_LABEL)) {
-            return myHeadModel; // or handle differently
-        }
-
-        // Get the model for this content
-        MyModel model = toolWindowService.getModelForContent(selectedContent);
-        if (model != null) {
-            return model;
-        }
-
-        // Fallback to HEAD
-        return myHeadModel;
+        return getModelForTabIndex(currentTabIndex);
     }
 
     public List<MyModel> getCollection() {
@@ -770,17 +734,35 @@ public class ViewService implements Disposable {
      * @return Map of file path to Change, or null if not initialized
      */
     private Map<String, Change> getChangesMapInternal(Function<MyModel, Map<String, Change>> mapGetter) {
-        // Early return if ViewService is not fully initialized yet
-        if (toolWindowService == null) {
-            return null;
-        }
-
         MyModel current = getCurrent();
         if (current == null) {
             return null;
         }
 
         return mapGetter.apply(current);
+    }
+
+    private MyModel getModelForTabIndex(int tabIndex) {
+        if (isDisposed) {
+            return myHeadModel;
+        }
+
+        if (tabIndex <= 0) {
+            return myHeadModel;
+        }
+
+        List<MyModel> models = collection;
+        if (models == null) {
+            return myHeadModel;
+        }
+
+        int modelIndex = getModelIndex(tabIndex);
+        if (modelIndex < 0 || modelIndex >= models.size()) {
+            return myHeadModel;
+        }
+
+        MyModel model = models.get(modelIndex);
+        return model != null ? model : myHeadModel;
     }
 
     /**


### PR DESCRIPTION
This one is to address the issue that I had encounter with the 2026.1. 

It was started with this exception:
  ```
  GitContentRevision.getContentAsBytes() should not be called from EDT

  java.lang.Throwable
  	at git4idea.GitContentRevision.getContentAsBytes(GitContentRevision.java:69)
  	at git4idea.GitContentRevision.getContent(GitContentRevision.java:57)
  	at implementation.lineStatusTracker.MyLineStatusTrackerImpl.updateLineStatusByChangesForEditor(MyLineStatusTrackerImpl.java:249)
  	at implementation.lineStatusTracker.MyLineStatusTrackerImpl.lambda$update$0(MyLineStatusTrackerImpl.java:228)
  	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:236)
  	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:22)
  	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:198)
  	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
  	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
  	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runWriteIntentReadAction(NestedLocksThreadingSupport.kt:705)
  	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:1094)
  	at com.intellij.openapi.application.impl.ApplicationImpl$7.lambda$run$0(ApplicationImpl.java:648)
  	at com.intellij.concurrency.ThreadContext.installThreadContext(threadContext.kt:305)
  	at com.intellij.openapi.application.impl.ApplicationImpl$7.run(ApplicationImpl.java:646)
  	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:192)
  	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:192)
  	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:198)
  	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:192)
  	at com.intellij.util.concurrency.ContextRunnable.lambda$run$0(ContextRunnable.java:26)
  	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
  	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:25)
  	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1$0(NonBlockingFlushQueue.kt:334)
  	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:928)
  	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1(NonBlockingFlushQueue.kt:333)
  	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
  	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1(NonBlockingFlushQueue.kt:330)
  	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunWriteIntentReadAction(NestedLocksThreadingSupport.kt:747)
  	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent(NonBlockingFlushQueue.kt:326)
  	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.flushNow(NonBlockingFlushQueue.kt:305)
  	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.FLUSH_NOW$lambda$0(NonBlockingFlushQueue.kt:167)
  	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:323)
  	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:732)
  	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:711)
  	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:720)
  	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:573)
  	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0$0$0(IdeEventQueue.kt:377)
  	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$0(IdeEventQueue.kt:1110)
  	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)
  	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1110)
  	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0(IdeEventQueue.kt:375)
  	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:415)
  	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
  	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
  	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
  	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
  	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
  	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
  ```
  
  Note: this PR is mainly coded by the codex, with some guidance. I've tested the solution in the IntelliJ 2026.1 (Build #IU-261.22158.277, built on March 25, 2026) and it seems to be working for me.